### PR TITLE
Add options: allow custom libtcc.dll file paths

### DIFF
--- a/common.lua
+++ b/common.lua
@@ -22,6 +22,7 @@ end
 
 common.user_opts = {
     never_disable_buttons = false,
+    tcc_dll_path =  "~~scripts/mpv-taskbar-buttons/libtcc.dll",
 
     prev_command = "",
     play_pause_command = "",

--- a/hook.lua
+++ b/hook.lua
@@ -39,6 +39,9 @@ local callbacks = {
     [common.button_ids[C.BUTTON_NEXT]] = function() mp.command(common.user_opts.next_command == "" and "playlist-next" or common.user_opts.next_command) end
 }
 
+local options = common.read_options()
+local tcc_dll_path = mp.command_native({ "expand-path", common.user_opts.tcc_dll_path })
+
 ffi.cdef [[
     // From lua.c @ e686297ecf3928b768c674bb10faa6f352b999b8
     struct script_ctx {
@@ -103,7 +106,7 @@ local function generate_hook_callback()
         void *tcc_get_symbol(TCCState *s, const char *name);
     ]]
 
-    local tcc =  ffi.load(script_dir .. "/libtcc.dll")
+    local tcc =  ffi.load(tcc_dll_path)
     local state = tcc.tcc_new()
     tcc.tcc_set_output_type(state, 1) -- TCC_OUTPUT_MEMORY
     tcc.tcc_set_options(state, "-nostdinc -nostdlib")

--- a/script-opts/mpv-taskbar-buttons.conf
+++ b/script-opts/mpv-taskbar-buttons.conf
@@ -1,4 +1,5 @@
 never_disable_buttons=no
+tcc_dll_path=~~scripts/mpv-taskbar-buttons/libtcc.dll
 prev_command=playlist-prev
 play_pause_command=cycle pause
 next_command=playlist-next


### PR DESCRIPTION
When using `tcc=libtcc.dll` option, the libtcc.dll file can be placed next to mpv.exe